### PR TITLE
Remove duplicate CSS definitions

### DIFF
--- a/tickets/static/tickets/css/ticket_display.css
+++ b/tickets/static/tickets/css/ticket_display.css
@@ -72,22 +72,3 @@ body {
   }
 }
 
-/* ticket_display.css */
-
-.ticket-list {
-  width: 100%;
-  margin: 0;         /* Убираем любые внешние отступы */
-  border-spacing: 0; /* Для table-fixed */
-}
-
-/* На очень узких экранах оставляем горизонтальный скролл */
-@media (max-width: 640px) {
-  .ticket-list {
-    font-size: 0.65rem;   /* Мелкий шрифт */
-  }
-  .ticket-list th,
-  .ticket-list td {
-    white-space: normal;   /* Разрешаем перенос слов */
-  }
-}
-


### PR DESCRIPTION
## Summary
- cleanup ticket_display.css by removing duplicate rule block

## Testing
- `python -m pip install -q -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Django==5.1.6)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6840611337408331a518c0e72360594d