### PR TITLE
Fix admin escape imports

### DIFF
--- a/tickets/admin.py
+++ b/tickets/admin.py
@@ -5,8 +5,7 @@ from django.urls import path, reverse
 from django.utils.html import format_html
 from django.shortcuts import render, get_object_or_404, redirect
 from django.utils.safestring import mark_safe
-from django.utils.html import escape
-from html import escape  # для экранирования пользовательских данных
+from html import escape as html_escape  # для экранирования пользовательских данных
 from django.forms.models import ModelChoiceField
 from django.contrib.auth import get_user_model
 
@@ -81,8 +80,8 @@ class TicketAdmin(admin.ModelAdmin):
             phones += f" / {obj.internal_phone}"
         return format_html(
             "<div>{}</div><div style='font-size:90%; color:#555;'>{}</div>",
-            escape(phones),
-            escape(obj.full_name)
+            html_escape(phones),
+            html_escape(obj.full_name)
         )
     contact_info.short_description = "Контакт"
 


### PR DESCRIPTION
## Summary
- remove unused `escape` from `django.utils.html`
- clarify remaining HTML escape usage

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Django==5.1.6)*
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684064389ff88331b850e065224bc246